### PR TITLE
feat: add argo-rollouts extension

### DIFF
--- a/charts/argo-cd-extensions/Chart.yaml
+++ b/charts/argo-cd-extensions/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.1.0
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd-extensions

--- a/charts/argo-cd-extensions/extensions/argo-rollouts.yaml
+++ b/charts/argo-cd-extensions/extensions/argo-rollouts.yaml
@@ -1,0 +1,10 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCDExtension
+metadata:
+  name: argo-rollouts
+  finalizers:
+    - extensions-finalizer.argocd.argoproj.io
+spec:
+  sources:
+  - web:
+      url: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.1.0/extension.tar

--- a/charts/argo-cd-extensions/templates/extensions.yaml
+++ b/charts/argo-cd-extensions/templates/extensions.yaml
@@ -1,0 +1,9 @@
+{{ $currentScope := .}}
+{{ range $path, $_ :=  .Files.Glob  "extensions/*.yaml" }}
+    {{- with $currentScope}}
+      {{- if has ($path | base | split ".")._0 .Values.extensions }}
+{{ .Files.Get $path }}
+---
+      {{- end }}
+    {{- end }}
+{{ end }}

--- a/charts/argo-cd-extensions/values.yaml
+++ b/charts/argo-cd-extensions/values.yaml
@@ -1,0 +1,3 @@
+# list of extensions to enable
+extensions:
+- argo-rollouts


### PR DESCRIPTION
Extension YAML are maintained in a `extensions/` directory.

To enable an extension, specify the name in values.yaml:

```
# list of extensions to enable
extensions:
- argo-rollouts
```

Signed-off-by: Jesse Suen <jessesuen@gmail.com>