### PR TITLE
chore: Upgrade ArgoCD umbrella charts

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: argo-cd-extensions
   repository: https://charts.akuity.io
-  version: 0.0.2
+  version: 0.0.3
 - name: argocd-image-updater
   repository: https://charts.akuity.io
-  version: 0.0.11
-digest: sha256:42549959600121f157e61ade9e895a3b08555ae94ce84cab61d14e775579919c
-generated: "2022-03-02T16:18:46.065411-05:00"
+  version: 0.1.0
+digest: sha256:56f3ecb708d6c8de965e46e4d037a73aab92f4a281af15b76b0dcb270e452838
+generated: "2022-03-02T17:34:36.923691-05:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.1.1
+version: 1.1.2
 appVersion: 2.3.0-rc5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
@@ -19,10 +19,10 @@ maintainers:
 
 dependencies:
   - name: argo-cd-extensions
-    version: 0.0.2
+    version: 0.0.3
     repository: https://charts.akuity.io
     condition: extensions.enabled
   - name: argocd-image-updater
-    version: 0.0.11
+    version: 0.1.0
     repository: https://charts.akuity.io
     condition: imageUpdater.enabled

--- a/charts/argo-cd/DOCS.md
+++ b/charts/argo-cd/DOCS.md
@@ -1,6 +1,6 @@
 # argo-cd
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 2.3.0-rc5](https://img.shields.io/badge/AppVersion-2.3.0--rc5-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 2.3.0-rc5](https://img.shields.io/badge/AppVersion-2.3.0--rc5-informational?style=flat-square)
 
 A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 
@@ -18,8 +18,8 @@ A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kube
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.akuity.io | argo-cd-extensions | 0.0.2 |
-| https://charts.akuity.io | argocd-image-updater | 0.0.11 |
+| https://charts.akuity.io | argo-cd-extensions | 0.0.3 |
+| https://charts.akuity.io | argocd-image-updater | 0.1.0 |
 
 ## Values
 


### PR DESCRIPTION
We have to update these after these versions are released. Otherwise, we will get an error when running `helm dependency update charts/argo-cd`:
```
Update Complete. ⎈Happy Helming!⎈
Error: can't get a valid version for repositories argocd-image-updater. Try changing the version constraint in Chart.yaml
```

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>