### PR TITLE
imageUpdater renamed to pass values to dependency

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -25,4 +25,4 @@ dependencies:
   - name: argocd-image-updater
     version: 0.1.0
     repository: https://charts.akuity.io
-    condition: imageUpdater.enabled
+    condition: argocd-image-updater.enabled, imageUpdater.enabled

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.1.7
+version: 1.1.8
 appVersion: 2.3.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -60,8 +60,8 @@ A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kube
 | global.image.pullPolicy | string | `nil` | If defined, an image pull policy will be applied to all ArgoCD deployments |
 | global.image.repository | string | `"quay.io/akuity/argocd"` | If defined, a repository applied to all ArgoCD deployments |
 | global.image.tag | string | `"v2.3.4-ak.0"` | If defined, a tag applied to all ArgoCD deployments |
-| imageUpdater | object | `{"enabled":false,"image":{"pullPolicy":null,"repository":"argoprojlabs/argocd-image-updater","tag":"v0.11.3"}}` | Image Updater |
-| imageUpdater.enabled | bool | `false` | Whether to enable image updater |
+| argocd-image-updater | object | `{"enabled":false,"image":{"pullPolicy":null,"repository":"argoprojlabs/argocd-image-updater","tag":"v0.11.3"}}` | Image Updater |
+| argocd-image-updater.enabled | bool | `false` | Whether to enable image updater |
 | notificationsController | object | `{"enabled":false}` | Notifications Controller |
 | notificationsController.enabled | bool | `false` | Whether to enable Notifications Controller |
 | redis | object | `{"enabled":true,"image":{"pullPolicy":null,"repository":"redis","tag":"6.2.6-alpine"},"resources":null}` | Redis configurations |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -348,7 +348,7 @@ extensions:
   # - argo-rollouts
 
 # -- Image Updater
-imageUpdater:
+argocd-image-updater:
   # -- Whether to enable image updater
   enabled: false
   image:


### PR DESCRIPTION
Values such as a custom image repository were not being passed into the subchart, so default values were always used. This updates condition name and parameter to argocd-image-updater to match the dependent chart name and related references and docs. It includes the original imageUpdater condition for backward compatibility. 