### PR TITLE
feat: upgrade argo-cd to v2.4.8

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 2.4.7-ak.0.0
-appVersion: 2.4.7
+version: 2.4.8-ak.0.0
+appVersion: 2.4.8
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
 home: https://charts.akuity.io

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -6,7 +6,7 @@ global:
     # -- If defined, a repository applied to all ArgoCD deployments
     repository: quay.io/akuity/argocd
     # -- If defined, a tag applied to all ArgoCD deployments
-    tag: v2.4.7-ak.0
+    tag: v2.4.8-ak.0
     # -- If defined, an image pull policy will be applied to all ArgoCD deployments
     pullPolicy: # IfNotPresent
   # -- Enable service monitor
@@ -272,7 +272,7 @@ dex:
 
   image:
     repository: ghcr.io/dexidp/dex
-    tag: v2.30.2
+    tag: v2.32.0
     pullPolicy: # IfNotPresent
 
   resources:
@@ -289,11 +289,11 @@ redis:
 
   image:
     repository: redis
-    tag: 7.0.0-alpine
+    tag: 7.0.4-alpine
     pullPolicy: # IfNotPresent
   haProxyImage:
     repository: haproxy
-    tag: 2.0.25-alpine
+    tag: 2.0.29-alpine
 
   resources:
   #  limits:


### PR DESCRIPTION
Upgrades Argo CD to v2.4.8
* version: 2.4.8-ak.0.0
* appVersion: 2.4.8
* https://github.com/argoproj/argo-cd/releases/tag/v2.4.8

Signed-off-by: Jesse Suen <jesse@akuity.io>