### PR TITLE
Argo CD Chart v2.5.0-ak.0.0

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 2.4.13-ak.0.0
-appVersion: 2.4.13
+version: 2.5.0-ak.0.0
+appVersion: 2.5.0
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
 home: https://charts.akuity.io

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1,6 +1,6 @@
 # argo-cd
 
-![Version: 2.4.13-ak.0.0](https://img.shields.io/badge/Version-2.4.13--ak.0.0-informational?style=flat-square) ![AppVersion: 2.4.13](https://img.shields.io/badge/AppVersion-2.4.13-informational?style=flat-square)
+![Version: 2.5.0-ak.0.0](https://img.shields.io/badge/Version-2.5.0--ak.0.0-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 
@@ -46,7 +46,7 @@ A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kube
 | dex.enabled | bool | `true` | Enbable or disables dex. Can be disabled if using native OAuth provider |
 | dex.image.pullPolicy | string | `nil` |  |
 | dex.image.repository | string | `"ghcr.io/dexidp/dex"` |  |
-| dex.image.tag | string | `"v2.35.0-distroless"` |  |
+| dex.image.tag | string | `"v2.35.3-distroless"` |  |
 | dex.resources | string | `nil` |  |
 | disasterRecovery | object | `{"activeDeadlineSeconds":540,"backupSchedule":"*/10 * * * *","bucketName":"","command":"argocd-backup.sh","enabled":false,"image":{"pullPolicy":null,"repository":null,"tag":null},"instanceName":""}` | Disaster recovery configurations |
 | disasterRecovery.activeDeadlineSeconds | int | `540` | Limits the maxium runtime when performing backup. This must be within the backup schedule. For example, we might want to limit this to 9-minutes if we run backups every 10 minutes |
@@ -60,13 +60,13 @@ A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kube
 | extensions.image.tag | string | `"v0.1.0"` |  |
 | global.image.pullPolicy | string | `nil` | If defined, an image pull policy will be applied to all ArgoCD deployments |
 | global.image.repository | string | `"quay.io/akuity/argocd"` | If defined, a repository applied to all ArgoCD deployments |
-| global.image.tag | string | `"v2.4.13-ak.0"` | If defined, a tag applied to all ArgoCD deployments |
+| global.image.tag | string | `"v2.5.0-ak.0"` | If defined, a tag applied to all ArgoCD deployments |
 | global.serviceMonitor | object | `{"enabled":false}` | Enable service monitor |
 | imageUpdater | object | `{"enabled":false,"image":{"pullPolicy":null,"repository":"quay.io/argoprojlabs/argocd-image-updater","tag":"v0.12.0"}}` | Image Updater |
 | imageUpdater.enabled | bool | `false` | Whether to enable image updater |
 | notificationsController | object | `{"enabled":false}` | Notifications Controller |
 | notificationsController.enabled | bool | `false` | Whether to enable Notifications Controller |
-| redis | object | `{"enabled":true,"haProxyImage":{"repository":"haproxy","tag":"2.0.29-alpine"},"image":{"pullPolicy":null,"repository":"redis","tag":"7.0.4-alpine"},"resources":null}` | Redis configurations |
+| redis | object | `{"enabled":true,"haProxyImage":{"repository":"haproxy","tag":"2.6.6-alpine"},"image":{"pullPolicy":null,"repository":"redis","tag":"7.0.5-alpine"},"resources":null}` | Redis configurations |
 | repoServer | object | `{"extraArgs":null,"image":{"pullPolicy":null,"repository":null,"tag":null},"replicas":2,"resources":null}` | Repo Server |
 | repoServer.extraArgs | string | `nil` | Additional command line arguments to pass to argocd-repo-server |
 | server | object | `{"enabled":true,"extraArgs":null,"image":{"pullPolicy":null,"repository":null,"tag":null},"ingress":{"annotations":{},"className":"","enabled":false,"host":"argocd.example.com","tls":{"enabled":false,"secretName":null}},"insecure":false,"replicas":2,"resources":null,"service":{"type":null}}` | Argo Server configuration |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -6,7 +6,7 @@ global:
     # -- If defined, a repository applied to all ArgoCD deployments
     repository: quay.io/akuity/argocd
     # -- If defined, a tag applied to all ArgoCD deployments
-    tag: v2.4.13-ak.0
+    tag: v2.5.0-ak.0
     # -- If defined, an image pull policy will be applied to all ArgoCD deployments
     pullPolicy: # IfNotPresent
   # -- Enable service monitor
@@ -272,7 +272,8 @@ dex:
 
   image:
     repository: ghcr.io/dexidp/dex
-    tag: v2.35.0-distroless
+    # https://github.com/dexidp/dex/pkgs/container/dex
+    tag: v2.35.3-distroless
     pullPolicy: # IfNotPresent
 
   resources:
@@ -289,11 +290,13 @@ redis:
 
   image:
     repository: redis
-    tag: 7.0.4-alpine
+    # https://hub.docker.com/_/redis/
+    tag: 7.0.5-alpine
     pullPolicy: # IfNotPresent
   haProxyImage:
+    # https://hub.docker.com/_/haproxy
     repository: haproxy
-    tag: 2.0.29-alpine
+    tag: 2.6.6-alpine
 
   resources:
   #  limits:
@@ -346,6 +349,7 @@ extensions:
 
   image:
     repository: ghcr.io/argoproj-labs/argocd-extensions
+    # https://github.com/argoproj-labs/argocd-extensions/pkgs/container/argocd-extensions
     tag: v0.1.0
     pullPolicy: # IfNotPresent
 
@@ -359,6 +363,7 @@ imageUpdater:
   # -- Whether to enable image updater
   enabled: false
   image:
+    # https://quay.io/repository/argoprojlabs/argocd-image-updater?tab=tags
     repository: quay.io/argoprojlabs/argocd-image-updater
     pullPolicy: # IfNotPresent
     tag: v0.12.0


### PR DESCRIPTION
Argo CD Chart `v2.5.0-ak.0.0`:
* `argo-cd: 2.5.0`          - https://github.com/argoproj/argo-cd/releases/tag/v2.5.0
* `dex: v2.35.3-distroless` - https://github.com/dexidp/dex/releases/tag/v2.35.3, https://github.com/dexidp/dex/compare/v2.35.0...v2.35.3
* `redis: 7.0.5-alpine`     - https://github.com/redis/redis/releases/tag/7.0.5, https://github.com/redis/redis/compare/7.0.4...7.0.5
* `haproxy: 2.6.6-alpine`   - https://www.haproxy.com/blog/announcing-haproxy-2-6/
                              https://docs.haproxy.org/2.6/intro.html
                              https://docs.haproxy.org/2.6/management.html