### PR TITLE
fix: set executor image explicitly

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 3.4.5-ak.2.0
+version: 3.4.5-ak.2.1
 appVersion: 3.4.5
 name: argo-workflows
 description: A Helm chart for Argo Workflows

--- a/charts/argo-workflows/templates/controller/aggregate-rbac.yaml
+++ b/charts/argo-workflows/templates/controller/aggregate-rbac.yaml
@@ -20,6 +20,8 @@ rules:
   - clusterworkflowtemplates/finalizers
   - workflowtasksets
   - workflowtasksets/finalizers
+  - workflowtaskresults
+  - workflowtaskresults/finalizers
   verbs:
   - create
   - delete
@@ -50,6 +52,8 @@ rules:
   - cronworkflows/finalizers
   - clusterworkflowtemplates
   - clusterworkflowtemplates/finalizers
+  - workflowtaskresults
+  - workflowtaskresults/finalizers
   verbs:
   - create
   - delete
@@ -80,6 +84,8 @@ rules:
   - cronworkflows/finalizers
   - clusterworkflowtemplates
   - clusterworkflowtemplates/finalizers
+  - workflowtaskresults
+  - workflowtaskresults/finalizers
   verbs:
   - get
   - list

--- a/charts/argo-workflows/templates/controller/cluster-rbac.yaml
+++ b/charts/argo-workflows/templates/controller/cluster-rbac.yaml
@@ -112,13 +112,13 @@ rules:
   - list
   - watch
 - apiGroups:
-    - argoproj.io
+  - argoproj.io
   resources:
-    - workflowtaskresults
+  - workflowtaskresults
   verbs:
-    - list
-    - watch
-    - deletecollection
+  - list
+  - watch
+  - deletecollection
 - apiGroups:
   - ""
   resources:
@@ -146,10 +146,10 @@ rules:
   - create
   - patch
 - apiGroups:
-    - "policy"
+  - policy
   resources:
-    - poddisruptionbudgets
+  - poddisruptionbudgets
   verbs:
-    - create
-    - get
-    - delete
+  - create
+  - get
+  - delete

--- a/charts/argo-workflows/templates/controller/deployment.yaml
+++ b/charts/argo-workflows/templates/controller/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     spec:
       containers:
       - args:
+        - --executor-image
+        - {{ .Values.executor.image.repository }}:{{ default .Values.global.image.tag .Values.executor.image.tag }}
         {{- with .Values.controller.extraArgs }}
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/argo-workflows/templates/server/cluster-rbac.yaml
+++ b/charts/argo-workflows/templates/server/cluster-rbac.yaml
@@ -23,8 +23,6 @@ rules:
   verbs:
   - get
   - create
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/charts/argo-workflows/templates/server/deployment.yaml
+++ b/charts/argo-workflows/templates/server/deployment.yaml
@@ -17,9 +17,7 @@ spec:
         {{- with .Values.server.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.server.secure }}
-        - --secure=true
-        {{- else }}
+        {{- if not .Values.server.secure }}
         - --secure=false
         {{- end }}
         image: {{ .Values.server.image.repository }}:{{ default .Values.global.image.tag .Values.server.image.tag }}
@@ -31,10 +29,10 @@ spec:
           httpGet:
             path: /
             port: 2746
-            {{- if .Values.server.secure }}
-            scheme: HTTPS
-            {{- else }}
+            {{- if not .Values.server.secure }}
             scheme: HTTP
+            {{- else }}
+            scheme: HTTPS
             {{- end }}
           initialDelaySeconds: 10
           periodSeconds: 20


### PR DESCRIPTION
Executor image should be set explicitly in command line args to workflow-controller. Otherwise, it will use images from quay.io/argoproj, which would not have our tags, resulting in image pull problems.

Also, fixes some missing changes from upstream manifests.