### PR TITLE
Openshift compatibility

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.6.7-ak.1.0
+version: 2.6.7-ak.0.1
 appVersion: 2.6.7
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.6.7-ak.0.0
+version: 2.6.7-ak.1.0
 appVersion: 2.6.7
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd

--- a/charts/argo-cd/templates/redis-ha/haproxy.yaml
+++ b/charts/argo-cd/templates/redis-ha/haproxy.yaml
@@ -31,7 +31,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - image: {{ .Values.redis.haProxyImage.repository }}:{{ .Values.redis.haProxyImage.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+        imagePullPolicy: {{ default .Values.global.image.pullPolicy }}
         lifecycle: {}
         livenessProbe:
           httpGet:
@@ -49,13 +49,10 @@ spec:
             port: 8888
           initialDelaySeconds: 5
           periodSeconds: 3
+        {{- with .Values.redis.securityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /usr/local/etc/haproxy
           name: data
@@ -67,7 +64,7 @@ spec:
         command:
         - sh
         image: {{ .Values.redis.haProxyImage.repository }}:{{ .Values.redis.haProxyImage.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+        imagePullPolicy: {{ default .Values.global.image.pullPolicy }}
         name: config-init
         securityContext:
           allowPrivilegeEscalation: false
@@ -83,9 +80,7 @@ spec:
         - mountPath: /data
           name: data
       securityContext:
-        fsGroup: 99
         runAsNonRoot: true
-        runAsUser: 99
       serviceAccountName: argocd-redis-ha-haproxy
       volumes:
       - configMap:

--- a/charts/argo-cd/templates/redis-ha/haproxy.yaml
+++ b/charts/argo-cd/templates/redis-ha/haproxy.yaml
@@ -80,7 +80,9 @@ spec:
         - mountPath: /data
           name: data
       securityContext:
+        fsGroup: 99
         runAsNonRoot: true
+        runAsUser: 99
       serviceAccountName: argocd-redis-ha-haproxy
       volumes:
       - configMap:

--- a/charts/argo-cd/templates/redis-ha/redis-ha-server.yaml
+++ b/charts/argo-cd/templates/redis-ha/redis-ha-server.yaml
@@ -34,7 +34,11 @@ spec:
         command:
         - redis-server
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+        imagePullPolicy: {{ default .Values.global.image.pullPolicy }}
+        {{- with .Values.redis.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         lifecycle:
           preStop:
             exec:
@@ -67,13 +71,10 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 15
+        {{- with .Values.redis.securityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /readonly-config
           name: config
@@ -87,7 +88,7 @@ spec:
         command:
         - redis-sentinel
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+        imagePullPolicy: {{ default .Values.global.image.pullPolicy }}
         lifecycle: {}
         livenessProbe:
           exec:
@@ -115,13 +116,10 @@ spec:
           periodSeconds: 15
           successThreshold: 3
           timeoutSeconds: 15
+        {{- with .Values.redis.securityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /data
           name: data
@@ -139,16 +137,13 @@ spec:
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+        imagePullPolicy: {{ default .Values.global.image.pullPolicy }}
         name: split-brain-fix
         resources: {}
+        {{- with .Values.redis.securityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /readonly-config
           name: config
@@ -168,15 +163,12 @@ spec:
         - name: SENTINEL_ID_2
           value: 2bbec7894d954a8af3bb54d13eaec53cb024e2ca
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy }}
+        imagePullPolicy: {{ default .Values.global.image.pullPolicy }}
         name: config-init
+        {{- with .Values.redis.securityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /readonly-config
           name: config
@@ -184,9 +176,7 @@ spec:
         - mountPath: /data
           name: data
       securityContext:
-        fsGroup: 1000
         runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: argocd-redis-ha
       terminationGracePeriodSeconds: 60
       volumes:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -8,7 +8,7 @@ global:
     # -- If defined, a tag applied to all ArgoCD deployments
     tag: v2.6.7-ak.0
     # -- If defined, an image pull policy will be applied to all ArgoCD deployments
-    pullPolicy: # IfNotPresent
+    pullPolicy: IfNotPresent
   # -- Enable service monitor
   serviceMonitor:
     enabled: false
@@ -289,14 +289,21 @@ redis:
   enabled: true
 
   image:
-    repository: redis
+    repository: quay.io/akuity/redis
     # https://hub.docker.com/_/redis/
-    tag: 7.0.8-alpine
+    tag: 7.0.4-alpine
     pullPolicy: # IfNotPresent
   haProxyImage:
     # https://hub.docker.com/_/haproxy
     repository: haproxy
     tag: 2.6.9-alpine
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    seccompProfile:
+      type: RuntimeDefault
 
   resources:
   #  limits:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -291,7 +291,7 @@ redis:
   image:
     repository: quay.io/akuity/redis
     # https://hub.docker.com/_/redis/
-    tag: 7.0.4-alpine
+    tag: 7.0.9-alpine
     pullPolicy: # IfNotPresent
   haProxyImage:
     # https://hub.docker.com/_/haproxy


### PR DESCRIPTION
* Fix empty `imagePullPolicy`
* Remove `runAsUser`
* put redis `securityContext` into values
* Add `resources` to redis
```
+ diff /var/folders/5p/0vf6kdgd6zq36rhdcm10d_4r0000gn/T/tmp.q90mbj0u/helm_v2.6.7.yaml /var/folders/5p/0vf6kdgd6zq36rhdcm10d_4r0000gn/T/tmp.q90mbj0u/upstream_v2.6.7.yaml
17921c17921
<         image: quay.io/akuity/redis:7.0.9-alpine
---
>         image: redis:7.0.8-alpine
17973c17973
<         image: quay.io/akuity/redis:7.0.9-alpine
---
>         image: redis:7.0.8-alpine
18024c18024
<         image: quay.io/akuity/redis:7.0.9-alpine
---
>         image: redis:7.0.8-alpine
18052c18052
<         image: quay.io/akuity/redis:7.0.9-alpine
---
>         image: redis:7.0.8-alpine
18067a18068
>         fsGroup: 1000
18068a18070
>         runAsUser: 1000
```