### PR TITLE
Add parameters to Argo CD chart

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.6.7-ak.0.1
+version: 2.6.7-ak.0.2
 appVersion: 2.6.7
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd

--- a/charts/argo-cd/templates/application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/application-controller/statefulset.yaml
@@ -45,6 +45,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         env:
+        {{- with .Values.controller.env }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         - name: ARGOCD_CONTROLLER_REPLICAS
           value: {{ .Values.controller.replicas | quote }}
         - name: ARGOCD_RECONCILIATION_TIMEOUT
@@ -188,6 +191,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
+        {{- with .Values.controller.volumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - mountPath: /app/config/controller/tls
           name: argocd-repo-server-tls
         - mountPath: /home/argocd
@@ -195,6 +201,9 @@ spec:
         workingDir: /home/argocd
       serviceAccountName: argocd-application-controller
       volumes:
+      {{- with .Values.controller.volumes }}
+        {{- toYaml . | nindent 6}}
+      {{- end }}
       - emptyDir: {}
         name: argocd-home
       - name: argocd-repo-server-tls

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -47,6 +47,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         env:
+        {{- with .Values.server.env }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         - name: ARGOCD_API_SERVER_REPLICAS
           value: {{ .Values.server.replicas | quote }}
         - name: ARGOCD_SERVER_INSECURE
@@ -270,6 +273,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
+        {{- with .Values.server.volumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
         - mountPath: /app/config/tls
@@ -294,6 +300,9 @@ spec:
 {{- end }}
       serviceAccountName: argocd-server
       volumes:
+      {{- with .Values.server.volumes }}
+        {{- toYaml . | nindent 6}}
+      {{- end }}
       - emptyDir: {}
         name: plugins-home
       - emptyDir: {}

--- a/charts/argo-cd/templates/config/repository-secret.yaml
+++ b/charts/argo-cd/templates/config/repository-secret.yaml
@@ -1,0 +1,13 @@
+{{- range $repo_key, $repo_value := .Values.config.repositories }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-repo-{{ $repo_key }}
+  labels:
+    argocd.argoproj.io/secret-type: repository
+data:
+  {{- range $key, $value := $repo_value }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/repo-server/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         env:
+        {{- with .Values.repoServer.env }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         - name: ARGOCD_RECONCILIATION_TIMEOUT
           valueFrom:
             configMapKeyRef:
@@ -201,6 +204,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
+        {{- with .Values.repoServer.volumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
         - mountPath: /app/config/tls
@@ -240,6 +246,9 @@ spec:
           name: var-files
       serviceAccountName: argocd-repo-server
       volumes:
+      {{- with .Values.repoServer.volumes }}
+        {{- toYaml . | nindent 6}}
+      {{- end }}
       - configMap:
           name: argocd-ssh-known-hosts-cm
         name: ssh-known-hosts

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -45,6 +45,21 @@ server:
     #   cpu: 50m
     #   memory: 64Mi
 
+  # env:
+  # - name: HTTPS_PROXY
+  #   value: example.com
+  # volumes:
+  # - name: trusted-ca
+  #   configMap:
+  #     name: example
+  #     items:
+  #     - key: ca-bundle.crt
+  #       path: ca-example.crt
+  # volumeMounts:
+  # - name: trusted-ca
+  #   mountPath: /etc/ssl/certs/
+  #   readOnly: true
+
   # -- Server service configuration
   service:
     type: # ClusterIP
@@ -97,6 +112,21 @@ controller:
     #   cpu: 250m
     #   memory: 256Mi
 
+  # env:
+  # - name: HTTPS_PROXY
+  #   value: example.com
+  # volumes:
+  # - name: trusted-ca
+  #   configMap:
+  #     name: example
+  #     items:
+  #     - key: ca-bundle.crt
+  #       path: ca-example.crt
+  # volumeMounts:
+  # - name: trusted-ca
+  #   mountPath: /etc/ssl/certs/
+  #   readOnly: true
+
 
 # -- Repo Server
 repoServer:
@@ -119,6 +149,21 @@ repoServer:
     # requests:
     #   cpu: 10m
     #   memory: 64Mi
+
+  # env:
+  # - name: HTTPS_PROXY
+  #   value: example.com
+  # volumes:
+  # - name: trusted-ca
+  #   configMap:
+  #     name: example
+  #     items:
+  #     - key: ca-bundle.crt
+  #       path: ca-example.crt
+  # volumeMounts:
+  # - name: trusted-ca
+  #   mountPath: /etc/ssl/certs/
+  #   readOnly: true
 
 
 # -- Notifications Controller

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -202,7 +202,14 @@ config:
     #       - name: company
     #       teamNameField: slug
     #       useLoginAsID: true
-
+  repositories: {}
+    # private-helm-repo:
+    #   url: https://my-private-chart-repo.internal
+    #   name: private-repo
+    #   type: helm
+    #   password: my-password
+    #   username: my-username
+      
 
   # -- Disable creation of the argocd-secret (e.g. if it managed elsewhere SealedSecret / ExternalSecret)
   createSecret: true


### PR DESCRIPTION
Parameters added:
* `env`, `volumes` and `volumeMounts` for argocd-server, application-controller and repo-server
* `config.repositories` to create repository secrets