### PR TITLE
feat: argo-cd v2.11.8

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 2.11.7-ak.0.0
-appVersion: 2.11.7
+version: 2.11.8-ak.0.0
+appVersion: 2.11.8
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
 home: https://charts.akuity.io

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1,6 +1,6 @@
 # argo-cd
 
-![Version: 2.11.7-ak.0.0](https://img.shields.io/badge/Version-2.11.7--ak.0.0-informational?style=flat-square) ![AppVersion: 2.11.7](https://img.shields.io/badge/AppVersion-2.11.7-informational?style=flat-square)
+![Version: 2.11.8-ak.0.0](https://img.shields.io/badge/Version-2.11.7--ak.0.0-informational?style=flat-square) ![AppVersion: 2.11.8](https://img.shields.io/badge/AppVersion-2.11.8-informational?style=flat-square)
 
 A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 
@@ -60,7 +60,7 @@ A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kube
 | imageUpdater.enabled | bool | `false` | Whether to enable image updater |
 | notificationsController | object | `{"enabled":true}` | Notifications Controller |
 | notificationsController.enabled | bool | `true` | Whether to enable Notifications Controller |
-| redis | object | `{"enabled":true,"haProxyImage":{"repository":"haproxy","tag":"2.6.14-alpine"},"image":{"pullPolicy":null,"repository":"quay.io/akuity/redis","tag":"7.0.15-alpine"},"resources":null}` | Redis configurations |
+| redis | object | `{"enabled":true,"haProxyImage":{"repository":"haproxy","tag":"2.6.14-alpine"},"networkPolicy":{"egress":{"enabled":true}},"image":{"pullPolicy":null,"repository":"quay.io/akuity/redis","tag":"7.0.15-alpine"},"resources":null}` | Redis configurations |
 | repoServer | object | `{"extraArgs":null,"image":{"pullPolicy":null,"repository":null,"tag":null},"replicas":2,"resources":null}` | Repo Server |
 | repoServer.extraArgs | string | `nil` | Additional command line arguments to pass to argocd-repo-server |
 | server | object | `{"enabled":true,"extraArgs":null,"image":{"pullPolicy":null,"repository":null,"tag":null},"ingress":{"annotations":{},"className":"","enabled":false,"host":"argocd.example.com","tls":{"enabled":false,"secretName":null}},"insecure":false,"replicas":2,"resources":null,"service":{"type":null}}` | Argo Server configuration |

--- a/charts/argo-cd/templates/redis-ha/redis-ha-networkpolicy.yaml
+++ b/charts/argo-cd/templates/redis-ha/redis-ha-networkpolicy.yaml
@@ -4,21 +4,6 @@ metadata:
   name: argocd-redis-ha-server-network-policy
   namespace: {{ .Release.Namespace }}
 spec:
-  egress:
-  - ports:
-    - port: 6379
-      protocol: TCP
-    - port: 26379
-      protocol: TCP
-    to:
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: argocd-redis-ha
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
   ingress:
   - from:
     - podSelector:
@@ -37,4 +22,21 @@ spec:
       app.kubernetes.io/name: argocd-redis-ha
   policyTypes:
   - Ingress
+  {{- if .Values.redis.networkPolicy.egress.enabled }}
   - Egress
+  egress:
+  - ports:
+    - port: 6379
+      protocol: TCP
+    - port: 26379
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-redis-ha
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -355,7 +355,9 @@ redis:
     # https://hub.docker.com/_/haproxy
     repository: haproxy
     tag: 2.6.14-alpine
-
+  networkPolicy:
+    egress:
+      enabled: true
   resources:
   #  limits:
   #    cpu: 200m


### PR DESCRIPTION
Upgrade to Argo CD v2.11.8

Also include the option to disable the egress rule in the `NetworkPolicy` for Redis HA.