### PR TITLE
feat: argo-cd v2.14.21

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 2.14.20-ak.0.0
-appVersion: 2.14.20
+version: 2.14.21-ak.0.0
+appVersion: 2.14.21
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
 home: https://charts.akuity.io

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1,6 +1,6 @@
 # argo-cd
 
-![Version: 2.14.20-ak.0.0](https://img.shields.io/badge/Version-2.14.20--ak.0.0-informational?style=flat-square) ![AppVersion: 2.14.20](https://img.shields.io/badge/AppVersion-2.14.20-informational?style=flat-square)
+![Version: 2.14.21-ak.0.0](https://img.shields.io/badge/Version-2.14.21--ak.0.0-informational?style=flat-square) ![AppVersion: 2.14.21](https://img.shields.io/badge/AppVersion-2.14.21-informational?style=flat-square)
 
 A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 
@@ -61,7 +61,7 @@ A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kube
 | imageUpdater.enabled | bool | `false` | Whether to enable image updater |
 | notificationsController | object | `{"enabled":true}` | Notifications Controller |
 | notificationsController.enabled | bool | `true` | Whether to enable Notifications Controller |
-| redis | object | `{"config":[],"enabled":true,"haProxyImage":{"repository":"public.ecr.aws/docker/library/haproxy","tag":"2.6.17-alpine"},"image":{"pullPolicy":null,"repository":"quay.io/akuity/redis","tag":"7.2.11-alpine"},"networkPolicy":{"egress":{"enabled":true}},"resources":null}` | Redis configurations |
+| redis | object | `{"config":[],"enabled":true,"haProxyImage":{"repository":"public.ecr.aws/docker/library/haproxy","tag":"2.6.17-alpine"},"image":{"pullPolicy":null,"repository":"quay.io/akuity/redis","tag":"7.2.12-alpine"},"networkPolicy":{"egress":{"enabled":true}},"resources":null}` | Redis configurations |
 | repoServer | object | `{"extraArgs":null,"image":{"pullPolicy":null,"repository":null,"tag":null},"replicas":2,"resources":null}` | Repo Server |
 | repoServer.extraArgs | string | `nil` | Additional command line arguments to pass to argocd-repo-server |
 | server | object | `{"enabled":true,"extraArgs":null,"image":{"pullPolicy":null,"repository":null,"tag":null},"ingress":{"annotations":{},"className":"","enabled":false,"host":"argocd.example.com","tls":{"enabled":false,"secretName":null}},"insecure":false,"replicas":2,"resources":null,"service":{"type":null}}` | Argo Server configuration |

--- a/charts/argo-cd/templates/config/repository-secret.yaml
+++ b/charts/argo-cd/templates/config/repository-secret.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     argocd.argoproj.io/secret-type: repository
   name: argocd-repo-{{ $repo_key }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
 data:
   {{- range $key, $value := $repo_value }}
-  {{ $key }}: {{ $value | b64enc }}
+  {{ $key }}: {{ $value | toString | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -360,7 +360,7 @@ redis:
   image:
     repository: quay.io/akuity/redis
     # https://hub.docker.com/_/redis/
-    tag: 7.2.11-alpine
+    tag: 7.2.12-alpine
     pullPolicy: # IfNotPresent
   haProxyImage:
     # https://hub.docker.com/_/haproxy

--- a/hack/compare-cd.sh
+++ b/hack/compare-cd.sh
@@ -47,7 +47,7 @@ namespace: foo
 images:
 - name: public.ecr.aws/docker/library/redis
   newName: quay.io/akuity/redis
-  newTag: 7.2.11-alpine
+  newTag: 7.2.12-alpine
 
 resources:
 - https://raw.githubusercontent.com/argoproj/argo-cd/v${upstream_version}/manifests/ha/install.yaml


### PR DESCRIPTION
Upgrades:
1. Argo CD v.2.14.21
2. Redis 7.2.12-alpine

Also fixes two issues in templates/config/repository-secret.yaml

1. Variable Scope Error in Range Loop:
Inside the range block, .Release.Namespace refers to the current loop context instead of the root, which results in a nil pointer error.

2. Non-String Values in Secret Data:
When non-string values (e.g., booleans or integers) were passed into .Values.config.repositories, Helm attempted to base64-encode them directly, which is invalid.


